### PR TITLE
support laravel 11 and horizon 5.24 and the latest carbon.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "laravel/horizon": "^5.21",
-        "nesbot/carbon": "^2.17",
-        "illuminate/support": "^8.17|^9.0|^10.0"
+        "laravel/horizon": "^5.24",
+        "nesbot/carbon": "^2.17 || ^3.0",
+        "illuminate/support": "^8.17|^9.0|^10.0|^11.0"
     }
 }


### PR DESCRIPTION
# Update Dependencies for Laravel 10 and Horizon 5 Compatibility

This pull request updates the dependencies of the `michaeldyrynda/laravel-horizon-cluster` package to ensure compatibility with Laravel 11 and Horizon 5.24. The following changes have been made to the `composer.json` file:

```json
"require": {
   "laravel/horizon": "^5.24",
   "nesbot/carbon": "^2.17 || ^3.0",
   "illuminate/support": "^8.17|^9.0|^10.0|^11.0"
}