### PR TITLE
Add Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     "require": {
         "laravel/horizon": "^5.21",
         "nesbot/carbon": "^2.17|^3.0",
-        "illuminate/support": "^9.21|^10.0|^11.0|^12.0"
+        "illuminate/support": "^9.21|^10.0|^11.0|^12.0|^13.0"
     }
 }

--- a/src/AppServiceProvider.php
+++ b/src/AppServiceProvider.php
@@ -7,6 +7,7 @@ use Laravel\Horizon\Contracts;
 use Laravel\Horizon\HorizonServiceProvider as Base;
 use Laravel\Horizon\Listeners;
 use Laravel\Horizon\Lock;
+use Laravel\Horizon\Notifications;
 use Laravel\Horizon\Repositories;
 use Laravel\Horizon\Stopwatch;
 
@@ -35,6 +36,9 @@ class AppServiceProvider extends Base
         Contracts\SupervisorRepository::class       => Mod\RedisSupervisorRepository::class, // Repositories\RedisSupervisorRepository::class
         Contracts\TagRepository::class              => Mod\RedisTagRepository::class, // Repositories\RedisTagRepository::class,
         Contracts\WorkloadRepository::class         => Repositories\RedisWorkloadRepository::class,
+
+        // Notifications...
+        Contracts\LongWaitDetectedNotification::class => Notifications\LongWaitDetected::class,
     ];
 
     /**

--- a/src/AppServiceProvider.php
+++ b/src/AppServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace Daison\LaravelHorizonCluster;
 
+use Illuminate\Redis\Connections\Connection;
 use Laravel\Horizon\AutoScaler;
 use Laravel\Horizon\Contracts;
+use Laravel\Horizon\Horizon;
 use Laravel\Horizon\HorizonServiceProvider as Base;
 use Laravel\Horizon\Listeners;
 use Laravel\Horizon\Lock;
@@ -51,27 +53,67 @@ class AppServiceProvider extends Base
      */
     protected function configure(): void
     {
-        if (!config('horizon.reconnect_to_next_node_on_fail', false)) {
-            parent::configure();
-
-            return;
-        }
-
         $this->mergeConfigFrom(
             dirname((new \ReflectionClass(get_parent_class($this)))->getFileName()) . '/../config/horizon.php',
             'horizon'
         );
 
-        $use = config('horizon.use', 'default');
+        $use = $this->normalizeConnectionName(config('horizon.use', 'default'));
 
-        if (
-            is_null($config = config("database.redis.clusters.$use"))
-            && is_null($config = config("database.redis.$use"))
-        ) {
-            throw new \Exception("Redis connection [$use] has not been configured.");
+        if (!config('horizon.reconnect_to_next_node_on_fail', false)) {
+            Horizon::use($use);
+
+            return;
         }
 
-        $config['options']['prefix'] = config('horizon.prefix') ?: 'horizon:';
+        if (! is_null($config = config("database.redis.clusters.$use"))) {
+            $this->configureClusterConnection($config);
+
+            return;
+        }
+
+        if (! is_null($config = config("database.redis.$use"))) {
+            $this->configureStandaloneConnection($config);
+
+            return;
+        }
+
+        throw new \Exception("Redis connection [$use] has not been configured.");
+    }
+
+    protected function normalizeConnectionName(string $connection): string
+    {
+        return str_starts_with($connection, 'clusters.')
+            ? substr($connection, strlen('clusters.'))
+            : $connection;
+    }
+
+    protected function configureClusterConnection(array $config): void
+    {
+        if (! method_exists(Connection::class, 'hasHashTag')) {
+            $this->configureStandaloneConnection($config[0]);
+
+            return;
+        }
+
+        $prefix = $this->ensureHashTaggedPrefix(config('horizon.prefix') ?: 'horizon:');
+
+        $config['options']['prefix'] = $prefix;
+
+        config(['horizon.prefix' => $prefix]);
+        config(['database.redis.clusters.horizon' => $config]);
+    }
+
+    protected function configureStandaloneConnection(array $config): void
+    {
+        $config['options']['prefix'] = $prefix = config('horizon.prefix') ?: 'horizon:';
+
+        config(['horizon.prefix' => $prefix]);
         config(['database.redis.horizon' => $config]);
+    }
+
+    protected function ensureHashTaggedPrefix(string $prefix): string
+    {
+        return Connection::hasHashTag($prefix) ? $prefix : '{'.$prefix.'}';
     }
 }


### PR DESCRIPTION
## Summary
- allow illuminate/support ^13 for Laravel 13 apps
- add Horizon's current LongWaitDetectedNotification service binding
- correct the Horizon cluster config example to use the cluster connection name

## Verification
- composer validate --strict
- php -l src/AppServiceProvider.php
- php -l src/Mod/*.php